### PR TITLE
chore: add a release github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: yarn install
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "rimraf dist && rollup -c",
     "test": "npm run build && ava",
-    "test:update-snapshots": "npm run build && ava --update-snapshots"
+    "test:update-snapshots": "npm run build && ava --update-snapshots",
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/process/RELEASE.md
+++ b/process/RELEASE.md
@@ -1,0 +1,20 @@
+# RELEASE PROCESS
+
+## Publishing a new release
+
+In the root directory run
+
+```sh
+node prepare-release.js <NEW VERSION NUMBER>
+```
+
+This will
+
+- Validate that the new version is greater than the current one
+- Update package.json to the new version number
+- Update CHANGELOG.md by running `standard-changelog`
+- Prompt you to create a release commit and tag it with the version number
+- Prompt you to push the commit and tag to origin
+
+This should in turn kick off the release Github Action at
+`.github/workflows/publish.yml`, which should publish the build to NPM.


### PR DESCRIPTION
that publishes to npm when a new release tag is added to the repo (through prepare-release.js).

Add process/RELEASE.md explaining the release process.