### PR TITLE
feat: add option.setAnonymousCrossOrigin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ export default {
 };
 ```
 
+## Options
+
+### `method`
+
+Type: `'preload' | 'import'`<br>
+Default: `'preload'`
+
+This controls whether to use link preload to preload the static dependencies or whether to use dynamic imports. The default is to use the link preload method.
+
+(See below for comparison of the methods)
+
+### `setAnonymousCrossOrigin`
+
+Type: `boolean`<br>
+Default: `true`
+
+Whether to set the crossorigin attribute of the link element to `'anonymous'` when using the link preload method. In certain cases setting this flag to `false` becomes necessary (See https://github.com/vikerman/rollup-plugin-hoist-import-deps/issues/12).
+
+Don't set this option to `false` unless you know what you are doing.
+
 ## Example
 
 Lets say you have a entry-point file `a.js` that dynamically imports `b.js`

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,12 @@ const VIRTUAL_ID_IMPORT = 'preloaddeps:import';
 const MARKER = '"__IMPORT_DEPS__"';
 
 export function hoistImportDeps(options) {
-  options = options || { method: 'preload' };
+  options = options || {};
+  options.method = options.method != null ? options.method : 'preload';
+  options.setAnonymousCrossOrigin =
+    options.setAnonymousCrossOrigin != null ? options.anononymousCrossOrigin : true;
 
-  // Get the static deps of a chunk and return them as list lietral of strings
+  // Get the static deps of a chunk and return them as list of strings
   // that can be passed as arguments to module preload method(__loadeDeps).
   const getDeps = (chunkName, bundle) => {
     let name = chunkName.startsWith('./') ? chunkName.substring(2) : chunkName;
@@ -60,7 +63,9 @@ export function __loadDeps(baseImport, ...deps) {
     for (const dep of deps) {
       if (seen.has(dep)) continue;
       const el = document.createElement('link');
-      Object.assign(el, { href: dep, rel: 'preload', as: 'script', crossorigin: 'anonymous', onload: () => el.remove() });
+      Object.assign(el, { href: dep, rel: 'preload', as: 'script', ${
+        options.setAnonymousCrossOrigin ? `crossorigin: 'anonymous',` : ''
+      } onload: () => el.remove() });
       document.head.appendChild(el);
       seen.add(dep);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,30 @@ test(`don't add __loadDeps wrapper if module has no (actual) dynamic imports`, t
   t.is(parseCalled, true);
 });
 
+test(`use link preload as method to preload by default`, t => {
+  const plugin = hoistImportDeps();
+  const moduleCode = plugin.load('preloaddeps:import');
+  t.assert(moduleCode.indexOf(`document.createElement('link')`) !== -1);
+});
+
+test(`use dynamic import if method is set to 'import'`, t => {
+  const plugin = hoistImportDeps({ method: 'import' });
+  const moduleCode = plugin.load('preloaddeps:import');
+  t.assert(moduleCode.indexOf(`import(dep)`) !== -1);
+});
+
+test(`add crossorigin attribute by default`, t => {
+  const plugin = hoistImportDeps();
+  const moduleCode = plugin.load('preloaddeps:import');
+  t.assert(moduleCode.indexOf(`crossorigin: 'anonymous'`) !== -1);
+});
+
+test(`don't add crossorigin attribute if options.setAnonymousCrossOrigin is set to false`, t => {
+  const plugin = hoistImportDeps({ setAnonymousCrossOrigin: false });
+  const moduleCode = plugin.load('preloaddeps:import');
+  t.assert(moduleCode.indexOf('crossorigin') === -1);
+});
+
 METHODS.forEach(method => {
   FORMATS.forEach(format => {
     test(`${format}:${method}:e2e`, async t => {


### PR DESCRIPTION
Don't set crossorigin attribute on link preload if the option is set to `false`. Defaults to `true`.

Fixes #12.

Also fixes #18.